### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build TypeScript
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Sky-Genesis-Enterprise/aether-mail/security/code-scanning/7](https://github.com/Sky-Genesis-Enterprise/aether-mail/security/code-scanning/7)

To fix the issue, add a `permissions` block at the root of the workflow file to explicitly define the minimal permissions required. Since this workflow only checks out the repository and installs dependencies, it likely only needs `contents: read` permissions. This ensures that the workflow cannot perform unintended write operations on the repository.

The `permissions` block should be added directly under the `name` field to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
